### PR TITLE
Fix/gps permission

### DIFF
--- a/lib/components/map_widget.dart
+++ b/lib/components/map_widget.dart
@@ -499,11 +499,10 @@ class MapWidgetState extends State<MapWidget> {
         });
   }
 
-  void onMapCreated(MapboxMapController controller) async {
+  void onMapCreated(MapboxMapController controller) {
     mapController = controller;
     mapController.addListener(_onMapChanged);
     _extractMapInfo();
-    if (sharedRoute != null) drawRoute(sharedRoute); 
-    //await requestLocationPermissionIfNotAlreadyGranted();
+    if (sharedRoute != null) drawRoute(sharedRoute);
   }
 }

--- a/lib/components/map_widget.dart
+++ b/lib/components/map_widget.dart
@@ -32,6 +32,8 @@ class MapWidgetState extends State<MapWidget> {
   final CameraPosition _cameraInitialPos;
   final CameraTargetBounds _cameraTargetBounds;
 
+  static bool _isCurrentlyGranting = false;
+
   static const platform =
       const MethodChannel('app.channel.hikingfornerds.data');
   HikingRoute sharedRoute;
@@ -86,6 +88,7 @@ class MapWidgetState extends State<MapWidget> {
     super.initState();
     _loadOfflineTiles();
     _getIntentData();
+    _requestPermissions();
   }
 
   Future<void> _getIntentData() async {
@@ -105,6 +108,10 @@ class MapWidgetState extends State<MapWidget> {
     else if (dataPath.endsWith(".gpx"))
       data = new GpxDataHandler().parseRouteFromString(dataPath);
     return data;
+  }
+
+  void _requestPermissions() async {
+    await requestLocationPermissionIfNotAlreadyGranted();
   }
 
   Future<void> _loadOfflineTiles() async {
@@ -372,8 +379,10 @@ class MapWidgetState extends State<MapWidget> {
 
   Future<void> requestLocationPermissionIfNotAlreadyGranted() async {
     bool granted = await isLocationPermissionGranted();
-    if (!granted) {
+    if (!granted && !_isCurrentlyGranting) {
+      _isCurrentlyGranting = true;
       await LocationPermissions().requestPermissions();
+      _isCurrentlyGranting = false;
       granted = await isLocationPermissionGranted();
       if (granted) forceRebuildMap();
     }
@@ -490,11 +499,11 @@ class MapWidgetState extends State<MapWidget> {
         });
   }
 
-  void onMapCreated(MapboxMapController controller) {
+  void onMapCreated(MapboxMapController controller) async {
     mapController = controller;
     mapController.addListener(_onMapChanged);
     _extractMapInfo();
     if (sharedRoute != null) drawRoute(sharedRoute); 
-    requestLocationPermissionIfNotAlreadyGranted();
+    //await requestLocationPermissionIfNotAlreadyGranted();
   }
 }


### PR DESCRIPTION
the issue is that, for some reason, the widget is being created twice and thus requests permission twice before the first one is handled. I fixed it by introducing a static field which gets set when a request is in progress and cleared when the request is done (irrespective whether it's granted or not)